### PR TITLE
Update rules and add jest plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eslint-config-sonarqube
 
-ESLint configuration for SonarQube and its plugins.
+ESLint configuration for SonarCloud, SonarQube and its plugins.
 
 ## Usage
 
@@ -10,6 +10,7 @@ Install:
 yarn add --dev \
   eslint-config-sonarqube \
   eslint-plugin-import \
+  eslint-plugin-jest \
   eslint-plugin-jsx-a11y \
   eslint-plugin-promise \
   eslint-plugin-react \

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ module.exports = {
     camelcase: "warn",
     "consistent-this": ["warn", "that"],
     "func-name-matching": "error",
-    "func-style": ["warn", "declaration", { allowArrowFunctions: true }],
+    "func-style": ["error", "declaration", { allowArrowFunctions: true }],
     "lines-between-class-members": [
       "error",
       "always",
@@ -144,6 +144,7 @@ module.exports = {
     "import/no-named-default": "error",
     "import/no-webpack-loader-syntax": "error",
     "import/no-useless-path-segments": ["error", { noUselessIndex: true }],
+    "import/prefer-default-export": "warn",
 
     // does not properly work with ts
     "import/no-unresolved": "off",
@@ -154,33 +155,24 @@ module.exports = {
       { missingExports: false, unusedExports: true }
     ], */
 
-    // react
-    // TODO turn all rules to "error" eventually
-    "react/button-has-type": "warn",
-    "react/display-name": "warn",
+    // react, customization of rules
+    "react/button-has-type": "error",
     "react/jsx-boolean-value": ["error", "always"],
-    "react/jsx-no-comment-textnodes": "warn",
-    "react/jsx-no-target-blank": "warn",
     "react/jsx-pascal-case": "error",
-    "react/jsx-sort-default-props": "warn",
-    "react/jsx-sort-props": "warn",
-    "react/jsx-fragments": ["warn", "syntax"],
+    "react/jsx-sort-default-props": "error",
+    "react/jsx-fragments": "error",
     "react/jsx-curly-spacing": [
       "error",
       { when: "never", allowMultiline: true }
     ],
     "react/jsx-curly-brace-presence": [
       "error",
-      { props: "never", children: "never" }
+      { props: "never", children: "ignore" }
     ],
-    "react/no-access-state-in-setstate": "warn",
-    "react/no-deprecated": "warn",
-    "react/no-find-dom-node": "warn",
-    "react/no-string-refs": "warn",
+    "react/no-access-state-in-setstate": "error",
     "react/no-this-in-sfc": "error",
     "react/no-typos": "error",
-    "react/no-unescaped-entities": "error",
-    "react/no-unused-state": "warn",
+    "react/no-unused-state": "error",
     "react/self-closing-comp": "error",
     "react/sort-comp": [
       "error",
@@ -196,9 +188,22 @@ module.exports = {
         groups: { rendering: ["/^render.+$/", "render"] }
       }
     ],
+    "react/no-redundant-should-component-update": "error",
+    "react/no-will-update-set-state": "error",
+    "react/no-unsafe": "error",
+    "react/void-dom-elements-no-children": "error"
+    "react/jsx-sort-props": "error",
 
     // turn off prop types validation, better use ts ;)
     "react/prop-types": "off",
+
+    // TODO turn all remaining rules to "error" eventually
+    "react/jsx-no-useless-fragment": "warn",
+    "react/no-array-index-key": "warn",
+    "react/no-danger": "warn",
+
+    // TODO could be activated at some point, but too many issues currently
+    "react/jsx-handler-names": "off",
 
     // react hooks
     "react-hooks/rules-of-hooks": "error",

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = {
     "eslint:recommended",
     "plugin:import/errors",
     "plugin:react/recommended",
+    "plugin:jest/recommended",
     "plugin:jsx-a11y/recommended",
     "plugin:promise/recommended",
     "plugin:sonarjs/recommended"
@@ -26,7 +27,7 @@ module.exports = {
 
   parser: "@typescript-eslint/parser",
 
-  plugins: ["import", "jsx-a11y", "react", "react-hooks", "promise", "sonarjs"],
+  plugins: ["import", "jest", "jsx-a11y", "react", "react-hooks", "promise", "sonarjs"],
 
   rules: {
     // possible errors
@@ -234,7 +235,21 @@ module.exports = {
     // sonarjs
     "sonarjs/cognitive-complexity": "warn",
     "sonarjs/no-duplicate-string": "warn",
-    "sonarjs/no-identical-functions": "warn"
+    "sonarjs/no-identical-functions": "warn",
+
+    // jest
+    "jest/no-truthy-falsy": "error",
+    "jest/consistent-test-it": ["error", { "fn": "it", "withinDescribe": "it" }],
+    "jest/no-duplicate-hooks": "error",
+    "jest/no-if": "error",
+    "jest/valid-title": "error",
+    'jest/no-disabled-tests': "error",
+    "jest/no-commented-out-tests": "error",
+    "jest/prefer-to-be-null": "error",
+    "jest/prefer-to-be-undefined": "error"
+
+    // TODO would be great to activate at some point
+    "jest/no-large-snapshots": ["off", { "maxSize": 50 }]
   },
 
   settings: {

--- a/index.js
+++ b/index.js
@@ -201,7 +201,6 @@ module.exports = {
     "react/no-will-update-set-state": "error",
     "react/no-unsafe": "error",
     "react/void-dom-elements-no-children": "error",
-    "react/jsx-sort-props": "error",
 
     // turn off prop types validation, better use ts ;)
     "react/prop-types": "off",

--- a/index.js
+++ b/index.js
@@ -27,7 +27,15 @@ module.exports = {
 
   parser: "@typescript-eslint/parser",
 
-  plugins: ["import", "jest", "jsx-a11y", "react", "react-hooks", "promise", "sonarjs"],
+  plugins: [
+    "import",
+    "jest",
+    "jsx-a11y",
+    "react",
+    "react-hooks",
+    "promise",
+    "sonarjs"
+  ],
 
   rules: {
     // possible errors
@@ -192,7 +200,7 @@ module.exports = {
     "react/no-redundant-should-component-update": "error",
     "react/no-will-update-set-state": "error",
     "react/no-unsafe": "error",
-    "react/void-dom-elements-no-children": "error"
+    "react/void-dom-elements-no-children": "error",
     "react/jsx-sort-props": "error",
 
     // turn off prop types validation, better use ts ;)
@@ -239,17 +247,17 @@ module.exports = {
 
     // jest
     "jest/no-truthy-falsy": "error",
-    "jest/consistent-test-it": ["error", { "fn": "it", "withinDescribe": "it" }],
+    "jest/consistent-test-it": ["error", { fn: "it", withinDescribe: "it" }],
     "jest/no-duplicate-hooks": "error",
     "jest/no-if": "error",
     "jest/valid-title": "error",
-    'jest/no-disabled-tests': "error",
+    "jest/no-disabled-tests": "error",
     "jest/no-commented-out-tests": "error",
     "jest/prefer-to-be-null": "error",
-    "jest/prefer-to-be-undefined": "error"
+    "jest/prefer-to-be-undefined": "error",
 
     // TODO would be great to activate at some point
-    "jest/no-large-snapshots": ["off", { "maxSize": 50 }]
+    "jest/no-large-snapshots": ["off", { maxSize: 50 }]
   },
 
   settings: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sonarqube",
-  "version": "0.6.0-rc2",
+  "version": "0.6.0",
   "description": "ESLint configuration for SonarQube and its plugins.",
   "main": "index.js",
   "license": "LGPL-3.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "LGPL-3.0",
   "peerDependencies": {
     "eslint-plugin-import": "^2.20.0",
+    "eslint-plugin-jest": "^23.6.0",
     "eslint-plugin-jsx-a11y": "^6.2.0",
     "eslint-plugin-promise": "^4.2.0",
     "eslint-plugin-react": "^7.17.0",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "main": "index.js",
   "license": "LGPL-3.0",
   "peerDependencies": {
-    "eslint-plugin-import": "^2.18.0",
+    "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-jsx-a11y": "^6.2.0",
-    "eslint-plugin-promise": "^4.1.0",
-    "eslint-plugin-react": "^7.14.0",
-    "eslint-plugin-react-hooks": "^1.6.0",
-    "eslint-plugin-sonarjs": "^0.4.0",
+    "eslint-plugin-promise": "^4.2.0",
+    "eslint-plugin-react": "^7.17.0",
+    "eslint-plugin-react-hooks": "^2.3.0",
+    "eslint-plugin-sonarjs": "^0.5.0",
     "@typescript-eslint/parser": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sonarqube",
-  "version": "0.5.1",
+  "version": "0.6.0-rc1",
   "description": "ESLint configuration for SonarQube and its plugins.",
   "main": "index.js",
   "license": "LGPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sonarqube",
-  "version": "0.6.0-rc1",
+  "version": "0.6.0-rc2",
   "description": "ESLint configuration for SonarQube and its plugins.",
   "main": "index.js",
   "license": "LGPL-3.0",


### PR DESCRIPTION
Here is a bit of cleaning and update of our eslint rules!
What has been done:
* Move some rules from "warn" to "error"
  * some of those changes have required a some update on SC repo side
  * some are auto fixable
  * some are not but didn't require a huge effort to do manually, we can still adapt if it's different in SQ repo, please try to update and tell me if there is too much work and we can adapt those
* Remove some react rule from our config to use the recommended profile instead
  * it always means going from "warn" to "error"
  * add some new rules for react
* Add jest plugin with recommended profile and some new rules
  * a lot of error are auto fixable
  * and the rest is actual issues or easy to fix manually

I published a first 0.6.0-rc2 release, so that you guys on SQ side can try it and I can update dependencies in SC.
We can then adjust some rules if needed and re-publish.

PS: I pinged all of you so that you can be aware of the changes I made if you are interested, but only one review from each team is enough :)

Related PR on SC: https://github.com/SonarSource/sonarcloud-core/pull/502
Related PR on sonar-ui-common: https://github.com/SonarSource/sonar-ui-common/pull/85