### PR TITLE
Upgrade to eslint 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ yarn add --dev \
   eslint-plugin-promise \
   eslint-plugin-react \
   eslint-plugin-react-hooks \
-  eslint-plugin-sonarjs \
   eslint \
   typescript-eslint-parser
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Install:
 
 ```
 yarn add --dev \
+  @typescript-eslint/eslint-plugin \
+  @typescript-eslint/parser \
+  eslint \
   eslint-config-sonarqube \
   eslint-plugin-import \
   eslint-plugin-jest \
@@ -15,10 +18,15 @@ yarn add --dev \
   eslint-plugin-promise \
   eslint-plugin-react \
   eslint-plugin-react-hooks \
-  eslint \
-  typescript-eslint-parser
 ```
 
 Configure:
 
 Add `extends: 'sonarqube'` to your local `.eslintrc`
+
+Release:
+
+1. Update the version in `package.json`
+2. Commit the change with a version message: `git commit -m "vx.y.z"`
+3. Tag the commit with the version : `git tag vx.y.z`
+4. Publish on npm: `yarn publish`

--- a/index.js
+++ b/index.js
@@ -6,14 +6,13 @@ module.exports = {
     "plugin:jest/recommended",
     "plugin:jsx-a11y/recommended",
     "plugin:promise/recommended",
-    "plugin:sonarjs/recommended"
   ],
 
   env: {
     browser: true,
     es6: true,
     jest: true,
-    node: true
+    node: true,
   },
 
   parserOptions: {
@@ -21,21 +20,13 @@ module.exports = {
     sourceType: "module",
     ecmaFeatures: {
       jsx: true,
-      modules: true
-    }
+      modules: true,
+    },
   },
 
   parser: "@typescript-eslint/parser",
 
-  plugins: [
-    "import",
-    "jest",
-    "jsx-a11y",
-    "react",
-    "react-hooks",
-    "promise",
-    "sonarjs"
-  ],
+  plugins: ["import", "jest", "jsx-a11y", "react", "react-hooks", "promise"],
 
   rules: {
     // possible errors
@@ -98,7 +89,7 @@ module.exports = {
     "lines-between-class-members": [
       "error",
       "always",
-      { exceptAfterSingleLine: true }
+      { exceptAfterSingleLine: true },
     ],
     "max-depth": "warn",
     "max-lines": ["warn", 1000],
@@ -116,7 +107,7 @@ module.exports = {
     "padding-line-between-statements": [
       "error",
       { blankLine: "always", prev: "*", next: ["class", "function"] },
-      { blankLine: "always", prev: ["class", "function"], next: "*" }
+      { blankLine: "always", prev: ["class", "function"], next: "*" },
     ],
 
     // es2015
@@ -238,11 +229,6 @@ module.exports = {
     "promise/always-return": "off",
     "promise/avoid-new": "off",
 
-    // sonarjs
-    "sonarjs/cognitive-complexity": "warn",
-    "sonarjs/no-duplicate-string": "warn",
-    "sonarjs/no-identical-functions": "warn",
-
     // jest
     "jest/no-truthy-falsy": "error",
     "jest/consistent-test-it": ["error", { fn: "it", withinDescribe: "it" }],
@@ -262,7 +248,7 @@ module.exports = {
     "import/ignore": ["node_modules"],
 
     react: {
-      version: "16.8"
-    }
-  }
+      version: "16.8",
+    },
+  },
 };

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = {
     "no-unsafe-negation": "error",
 
     // best practices
-    // TODO turn all rules to "error" eventually
+    // turn all rules to "error" eventually
     "array-callback-return": "error",
     "block-scoped-var": "error",
     complexity: "warn",
@@ -154,24 +154,34 @@ module.exports = {
       { missingExports: false, unusedExports: true }
     ], */
 
-    // react, customization of rules
+    // react
+    // overwrite recomended
+    "react/no-unsafe": "error",
+    "react/prop-types": "off", // turn off prop types validation, better use ts ;)
+
+    // not in recomended
     "react/button-has-type": "error",
+    "react/jsx-no-script-url": "error",
     "react/jsx-boolean-value": ["error", "always"],
     "react/jsx-pascal-case": "error",
     "react/jsx-sort-default-props": "error",
     "react/jsx-fragments": "error",
     "react/jsx-curly-spacing": [
       "error",
-      { when: "never", allowMultiline: true }
+      { when: "never", allowMultiline: true },
     ],
     "react/jsx-curly-brace-presence": [
       "error",
-      { props: "never", children: "ignore" }
+      { props: "never", children: "ignore" },
     ],
     "react/no-access-state-in-setstate": "error",
     "react/no-this-in-sfc": "error",
     "react/no-typos": "error",
     "react/no-unused-state": "error",
+    "react/no-redundant-should-component-update": "error",
+    "react/no-will-update-set-state": "error",
+    "react/no-adjacent-inline-elements": "error",
+    "react/no-unused-prop-types": "error",
     "react/self-closing-comp": "error",
     "react/sort-comp": [
       "error",
@@ -182,46 +192,48 @@ module.exports = {
           "static-methods",
           "lifecycle",
           "everything-else",
-          "rendering"
+          "rendering",
         ],
-        groups: { rendering: ["/^render.+$/", "render"] }
-      }
+        groups: { rendering: ["/^render.+$/", "render"] },
+      },
     ],
-    "react/no-redundant-should-component-update": "error",
-    "react/no-will-update-set-state": "error",
-    "react/no-unsafe": "error",
     "react/void-dom-elements-no-children": "error",
 
-    // turn off prop types validation, better use ts ;)
-    "react/prop-types": "off",
-
-    // TODO turn all remaining rules to "error" eventually
+    // turn all remaining rules to "error" eventually
+    "react/style-prop-object": "warn",
     "react/jsx-no-useless-fragment": "warn",
     "react/no-array-index-key": "warn",
     "react/no-danger": "warn",
+    "react/function-component-definition": [
+      "warn",
+      {
+        namedComponents: "function-declaration",
+        unnamedComponents: "function-expression",
+      },
+    ],
 
-    // TODO could be activated at some point, but too many issues currently
-    "react/jsx-handler-names": "off",
+    "react/jsx-handler-names": "off", // could be activated at some point, but too many issues currently
 
     // react hooks
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
 
     // jsx-a11y
+    // error in recomended
     "jsx-a11y/anchor-has-content": "warn",
-    "jsx-a11y/control-has-associated-label": "warn",
     "jsx-a11y/label-has-associated-control": "warn",
     "jsx-a11y/no-noninteractive-tabindex": "warn",
     "jsx-a11y/no-redundant-roles": "warn",
     "jsx-a11y/no-static-element-interactions": "warn",
-
     "jsx-a11y/accessible-emoji": "off",
     "jsx-a11y/anchor-is-valid": "off",
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/no-autofocus": "off",
     "jsx-a11y/no-noninteractive-element-interactions": "off",
-    // has FPs
-    "jsx-a11y/label-has-for": "off",
+    "jsx-a11y/label-has-for": "off", // has FPs
+
+    // not in recomended
+    "jsx-a11y/control-has-associated-label": "warn",
 
     // promise
     "promise/catch-or-return": ["warn", { allowThen: true }],
@@ -230,18 +242,29 @@ module.exports = {
     "promise/avoid-new": "off",
 
     // jest
-    "jest/no-truthy-falsy": "error",
+    // overwrite recomended
+    "jest/no-disabled-tests": "error",
+    "jest/no-commented-out-tests": "error",
+
+    // not in recomended
+    "jest/no-restricted-matchers": [
+      "error",
+      {
+        toBeTruthy: "Avoid `toBeTruthy`",
+        toBeFalsy: "Avoid `toBeFalsy`",
+      },
+    ],
     "jest/consistent-test-it": ["error", { fn: "it", withinDescribe: "it" }],
     "jest/no-duplicate-hooks": "error",
     "jest/no-if": "error",
     "jest/valid-title": "error",
-    "jest/no-disabled-tests": "error",
-    "jest/no-commented-out-tests": "error",
     "jest/prefer-to-be-null": "error",
     "jest/prefer-to-be-undefined": "error",
 
-    // TODO would be great to activate at some point
-    "jest/no-large-snapshots": ["off", { maxSize: 50 }]
+    "jest/no-interpolation-in-snapshots": "warn",
+    "jest/no-conditional-expect": "warn",
+
+    "jest/no-large-snapshots": ["off", { maxSize: 50 }], // would be great to activate at some point
   },
 
   settings: {

--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 module.exports = {
   extends: [
     "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
     "plugin:import/errors",
-    "plugin:react/recommended",
     "plugin:jest/recommended",
     "plugin:jsx-a11y/recommended",
     "plugin:promise/recommended",
+    "plugin:react/recommended",
   ],
 
   env: {
@@ -26,27 +27,29 @@ module.exports = {
 
   parser: "@typescript-eslint/parser",
 
-  plugins: ["import", "jest", "jsx-a11y", "react", "react-hooks", "promise"],
+  plugins: [
+    "@typescript-eslint",
+    "import",
+    "jest",
+    "jsx-a11y",
+    "promise",
+    "react",
+    "react-hooks",
+  ],
 
   rules: {
-    // possible errors
-    "for-direction": "error",
-    "no-prototype-builtins": "error",
-    "no-template-curly-in-string": "error",
-    "no-unsafe-negation": "error",
-
-    // best practices
-    // turn all rules to "error" eventually
-    "array-callback-return": "error",
+    // not in eslint:recomended, turn all rules to "error" eventually
     "block-scoped-var": "error",
-    complexity: "warn",
     curly: "error",
-    "consistent-return": "warn",
     eqeqeq: ["error", "smart"],
     "guard-for-in": "error",
+    "handle-callback-err": "error",
     "no-alert": "error",
+    "no-await-in-loop": "error",
     "no-caller": "error",
     "no-console": "error",
+    "no-constructor-return": "error",
+    "no-continue": "error",
     "no-div-regex": "error",
     "no-eval": "error",
     "no-extend-native": "error",
@@ -58,25 +61,28 @@ module.exports = {
     "no-labels": "error",
     "no-lone-blocks": "error",
     "no-loop-func": "error",
-    "no-new": "warn",
+    "no-new": "error",
     "no-new-func": "error",
     "no-new-wrappers": "error",
+    "no-promise-executor-return": "error",
     "no-proto": "error",
     "no-restricted-properties": "error",
     "no-return-assign": "error",
     "no-return-await": "error",
     "no-self-compare": "error",
     "no-sequences": "error",
+    "no-template-curly-in-string": "error",
     "no-throw-literal": "error",
     "no-unmodified-loop-condition": "error",
+    "no-unsafe-optional-chaining": "error",
     "no-unused-expressions": "error",
     "no-useless-call": "error",
     "no-useless-concat": "error",
-    "no-useless-escape": "error",
+    "no-useless-constructor": "error",
     "no-useless-return": "error",
     "no-void": "error",
-    "no-with": "error",
     radix: "error",
+    "require-atomic-updates": "error",
     "require-await": "error",
     "wrap-iife": "error",
     yoda: "error",
@@ -84,6 +90,7 @@ module.exports = {
     // stylistic
     camelcase: "warn",
     "consistent-this": ["warn", "that"],
+    "eol-last": "warn",
     "func-name-matching": "error",
     "func-style": ["error", "declaration", { allowArrowFunctions: true }],
     "lines-between-class-members": [
@@ -92,13 +99,9 @@ module.exports = {
       { exceptAfterSingleLine: true },
     ],
     "max-depth": "warn",
-    "max-lines": ["warn", 1000],
-    "max-params": ["warn", 4],
-    "no-array-constructor": "warn",
-    "no-bitwise": "warn",
+    "no-else-return": "warn",
     "no-lonely-if": "error",
     "no-multi-assign": "warn",
-    "no-nested-ternary": "warn",
     "no-new-object": "warn",
     "no-underscore-dangle": "warn",
     "no-unneeded-ternary": "warn",
@@ -114,19 +117,17 @@ module.exports = {
     "no-duplicate-imports": "error",
     "no-useless-computed-key": "error",
     "no-useless-rename": "error",
-    "no-var": "error",
     "object-shorthand": "error",
     "prefer-arrow-callback": "error",
-    "prefer-const": "error",
     "prefer-destructuring": ["warn", { object: true, array: false }],
     "prefer-numeric-literals": "warn",
+
+    // override @typescript-eslint/eslint-recommended
+    "no-unused-vars": "off",
+    "no-array-constructor": "off",
+    "no-extra-semi": "off",
     "prefer-rest-params": "warn",
     "prefer-spread": "warn",
-
-    // disabled because of the usage of typescript-eslint-parser
-    // https://github.com/eslint/typescript-eslint-parser/issues/77
-    "no-undef": "off",
-    "no-unused-vars": "off",
 
     // import
     "import/extensions": ["error", "never", { json: "always", md: "always" }],
@@ -155,7 +156,7 @@ module.exports = {
     ], */
 
     // react
-    // overwrite recomended
+    // override recomended
     "react/no-unsafe": "error",
     "react/prop-types": "off", // turn off prop types validation, better use ts ;)
 
@@ -197,10 +198,10 @@ module.exports = {
         groups: { rendering: ["/^render.+$/", "render"] },
       },
     ],
+    "react/style-prop-object": "error",
     "react/void-dom-elements-no-children": "error",
 
     // turn all remaining rules to "error" eventually
-    "react/style-prop-object": "warn",
     "react/jsx-no-useless-fragment": "warn",
     "react/no-array-index-key": "warn",
     "react/no-danger": "warn",
@@ -212,7 +213,8 @@ module.exports = {
       },
     ],
 
-    "react/jsx-handler-names": "off", // could be activated at some point, but too many issues currently
+    // could be activated at some point, but too many issues currently
+    "react/jsx-handler-names": "off",
 
     // react hooks
     "react-hooks/rules-of-hooks": "error",
@@ -242,9 +244,10 @@ module.exports = {
     "promise/avoid-new": "off",
 
     // jest
-    // overwrite recomended
+    // override recomended
     "jest/no-disabled-tests": "error",
     "jest/no-commented-out-tests": "error",
+    "jest/no-jasmine-globals": "warn",
 
     // not in recomended
     "jest/no-restricted-matchers": [
@@ -257,12 +260,8 @@ module.exports = {
     "jest/consistent-test-it": ["error", { fn: "it", withinDescribe: "it" }],
     "jest/no-duplicate-hooks": "error",
     "jest/no-if": "error",
-    "jest/valid-title": "error",
     "jest/prefer-to-be-null": "error",
     "jest/prefer-to-be-undefined": "error",
-
-    "jest/no-interpolation-in-snapshots": "warn",
-    "jest/no-conditional-expect": "warn",
 
     "jest/no-large-snapshots": ["off", { maxSize: 50 }], // would be great to activate at some point
   },

--- a/package.json
+++ b/package.json
@@ -4,14 +4,18 @@
   "description": "ESLint configuration for SonarQube and its plugins.",
   "main": "index.js",
   "license": "LGPL-3.0",
+  "engines": {
+    "node": ">=10.12.0"
+  },
   "peerDependencies": {
-    "eslint": ">= 6.8",
-    "eslint-plugin-import": ">= 2.20.0",
-    "eslint-plugin-jest": ">= 23.20.0",
+    "@typescript-eslint/eslint-plugin": ">= 4.13.0",
+    "@typescript-eslint/parser": ">= 4.13.0",
+    "eslint": ">= 7.17.0",
+    "eslint-plugin-import": ">= 2.22.0",
+    "eslint-plugin-jest": ">= 24.1.0",
     "eslint-plugin-jsx-a11y": ">= 6.4.0",
     "eslint-plugin-promise": ">= 4.2.0",
     "eslint-plugin-react": ">= 7.22.0",
-    "eslint-plugin-react-hooks": ">= 2.5.0",
-    "@typescript-eslint/parser": ">= 2.24"
+    "eslint-plugin-react-hooks": ">= 4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sonarqube",
-  "version": "0.7.0",
+  "version": "1.0.0-rc1",
   "description": "ESLint configuration for SonarQube and its plugins.",
   "main": "index.js",
   "license": "LGPL-3.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "eslint-plugin-promise": "^4.2.0",
     "eslint-plugin-react": "^7.17.0",
     "eslint-plugin-react-hooks": "^2.3.0",
-    "eslint-plugin-sonarjs": "^0.5.0",
     "@typescript-eslint/parser": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sonarqube",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "ESLint configuration for SonarQube and its plugins.",
   "main": "index.js",
   "license": "LGPL-3.0",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "main": "index.js",
   "license": "LGPL-3.0",
   "peerDependencies": {
-    "eslint-plugin-import": "^2.20.0",
-    "eslint-plugin-jest": "^23.6.0",
-    "eslint-plugin-jsx-a11y": "^6.2.0",
-    "eslint-plugin-promise": "^4.2.0",
-    "eslint-plugin-react": "^7.17.0",
-    "eslint-plugin-react-hooks": "^2.3.0",
-    "@typescript-eslint/parser": "*"
+    "eslint": ">= 6.8",
+    "eslint-plugin-import": ">= 2.20.0",
+    "eslint-plugin-jest": ">= 23.20.0",
+    "eslint-plugin-jsx-a11y": ">= 6.4.0",
+    "eslint-plugin-promise": ">= 4.2.0",
+    "eslint-plugin-react": ">= 7.22.0",
+    "eslint-plugin-react-hooks": ">= 2.5.0",
+    "@typescript-eslint/parser": ">= 2.24"
   }
 }


### PR DESCRIPTION
Here it is! There should not be too many new issues. I think I had to fix around 50 of them on SC codebase, and a few more with autofix. So I hope it will be smooth for you too!

I did too versions, the 0.7.0, which is not published yet, that only update the plugins and drop the sonarjs plugin, activate a few new rules. I let you publish it if you want to first update to this one.

And the 1.0.0-rc1, which is published already and used by SC. Which enforce the use of the latest eslint. It also means some breaking changes like nodejs 10.12 as minimum required version. Some new rules from latest eslint and some more cleaning of the config.