### PR TITLE
fix(jest): remove non-existing rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,8 +263,7 @@ module.exports = {
     "jest/consistent-test-it": ["error", { fn: "it", withinDescribe: "it" }],
     "jest/no-duplicate-hooks": "error",
     "jest/no-if": "error",
-    "jest/prefer-to-be-null": "error",
-    "jest/prefer-to-be-undefined": "error",
+    "jest/prefer-to-be": "error",
 
     "jest/no-large-snapshots": ["off", { maxSize: 50 }], // would be great to activate at some point
   },


### PR DESCRIPTION
These 2 rules have been from `eslint-plugin-jest` for a while now which will mean this config in its current state will cause fatal errors when eslint tries to parse the config

`eslint-plugin-jest` changelog entry: https://github.com/jest-community/eslint-plugin-jest/blob/main/CHANGELOG.md#2500-2021-10-10

The replacement is: https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-to-be.md

Sidenote that upon merging I would *really* appreciate a release to NPM as we use this config in a project for work and right now we need to explicitly disable these 2 rules in order for ESLint to run at all.