### PR TITLE
Update to latest eslint v8

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.0.0-rc (2022-05.27)
+# 2.0.0 (2022-05-31)
 
 Breaking changes:
 
@@ -16,7 +16,7 @@ Plugins updates:
 
 Rules changes:
 
-- Replace jest/no-if by jest/no-conditional-in-test
+- Replace jest/no-if by jest/no-conditional-in-test in warn mode instead of error
 - Add jest/prefer-equality-matcher
 - Add jest/prefer-comparison-matcher
 - Add react/hook-use-state

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# 2.0.0-rc (2022-05.27)
+
+Breaking changes:
+
+- Raise minimum nodejs version from v10.12 to v12.22
+- Upgrade eslint from v7 to v8
+
+Plugins updates:
+
+- Raise minimum version of eslint-plugin-import to v2.25
+- Raise minimum version of eslint-plugin-jsx-a11y v6.5
+- Raise minimum version of eslint-plugin-promise v6
+- Raise minimum version of eslint-plugin-react v7.30
+- Raise minimum version of eslint-plugin-react-hooks v4.3
+- Raise minimum version of eslint-plugin-jest v26.1
+
+Rules changes:
+
+- Replace jest/no-if by jest/no-conditional-in-test
+- Add jest/prefer-equality-matcher
+- Add jest/prefer-comparison-matcher
+- Add react/hook-use-state
+- Add react/no-arrow-function-lifecycle
+- Add react/no-namespace
+- Disable react/jsx-no-leaked-render due to too many FP
+- allowExpressions in react/jsx-no-useless-fragment
+
 # 1.1.0 (2022-05-24)
 
 - Bump eslint-plugin-jest to v25 ([#9](https://github.com/SonarSource/eslint-config-sonarqube/pull/9))

--- a/index.js
+++ b/index.js
@@ -203,9 +203,12 @@ module.exports = {
     ],
     "react/style-prop-object": "error",
     "react/void-dom-elements-no-children": "error",
+    "react/hook-use-state": "error",
+    "react/no-arrow-function-lifecycle": "error",
+    "react/no-namespace": "error",
 
     // turn all remaining rules to "error" eventually
-    "react/jsx-no-useless-fragment": "warn",
+    "react/jsx-no-useless-fragment": ["warn", { allowExpressions: true }],
     "react/no-array-index-key": "warn",
     "react/no-danger": "warn",
     "react/function-component-definition": [
@@ -218,6 +221,7 @@ module.exports = {
 
     // could be activated at some point, but too many issues currently
     "react/jsx-handler-names": "off",
+    "react/jsx-no-leaked-render": "off", // too many false positives right now
 
     // react hooks
     "react-hooks/rules-of-hooks": "error",

--- a/index.js
+++ b/index.js
@@ -266,7 +266,9 @@ module.exports = {
     ],
     "jest/consistent-test-it": ["error", { fn: "it", withinDescribe: "it" }],
     "jest/no-duplicate-hooks": "error",
-    "jest/no-if": "error",
+    "jest/no-conditional-in-test": "error",
+    "jest/prefer-equality-matcher": "error",
+    "jest/prefer-comparison-matcher": "error",
 
     "jest/no-large-snapshots": ["off", { maxSize: 50 }], // would be great to activate at some point
   },

--- a/index.js
+++ b/index.js
@@ -266,10 +266,10 @@ module.exports = {
     ],
     "jest/consistent-test-it": ["error", { fn: "it", withinDescribe: "it" }],
     "jest/no-duplicate-hooks": "error",
-    "jest/no-conditional-in-test": "error",
     "jest/prefer-equality-matcher": "error",
     "jest/prefer-comparison-matcher": "error",
 
+    "jest/no-conditional-in-test": "warn",
     "jest/no-large-snapshots": ["off", { maxSize: 50 }], // would be great to activate at some point
   },
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@typescript-eslint/parser": ">= 5.0.0",
     "eslint": ">= 8.0.0",
     "eslint-plugin-import": ">= 2.25.0",
-    "eslint-plugin-jest": ">= 25.0.0",
+    "eslint-plugin-jest": ">= 26.1.0",
     "eslint-plugin-jsx-a11y": ">= 6.5.0",
     "eslint-plugin-promise": ">= 6.0.0",
     "eslint-plugin-react": ">= 7.30.0",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "node": ">=12.22.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": ">= 4.13.0",
-    "@typescript-eslint/parser": ">= 4.13.0",
-    "eslint": ">= 7.17.0",
+    "@typescript-eslint/eslint-plugin": ">= 5.0.0",
+    "@typescript-eslint/parser": ">= 5.0.0",
+    "eslint": ">= 8.0.0",
     "eslint-plugin-import": ">= 2.22.0",
     "eslint-plugin-jest": ">= 25.0.0",
     "eslint-plugin-jsx-a11y": ">= 6.4.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "eslint-plugin-jest": ">= 25.0.0",
     "eslint-plugin-jsx-a11y": ">= 6.5.0",
     "eslint-plugin-promise": ">= 6.0.0",
-    "eslint-plugin-react": ">= 7.22.0",
-    "eslint-plugin-react-hooks": ">= 4.2.0"
+    "eslint-plugin-react": ">= 7.30.0",
+    "eslint-plugin-react-hooks": ">= 4.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sonarqube",
-  "version": "1.1.0",
+  "version": "2.0.0-rc",
   "description": "ESLint configuration for SonarQube and its plugins.",
   "main": "index.js",
   "license": "LGPL-3.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "license": "LGPL-3.0",
   "engines": {
-    "node": ">=10.12.0"
+    "node": ">=12.22.0"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": ">= 4.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sonarqube",
-  "version": "2.0.0-rc",
+  "version": "2.0.0",
   "description": "ESLint configuration for SonarQube and its plugins.",
   "main": "index.js",
   "license": "LGPL-3.0",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "@typescript-eslint/eslint-plugin": ">= 5.0.0",
     "@typescript-eslint/parser": ">= 5.0.0",
     "eslint": ">= 8.0.0",
-    "eslint-plugin-import": ">= 2.22.0",
+    "eslint-plugin-import": ">= 2.25.0",
     "eslint-plugin-jest": ">= 25.0.0",
-    "eslint-plugin-jsx-a11y": ">= 6.4.0",
-    "eslint-plugin-promise": ">= 4.2.0",
+    "eslint-plugin-jsx-a11y": ">= 6.5.0",
+    "eslint-plugin-promise": ">= 6.0.0",
     "eslint-plugin-react": ">= 7.22.0",
     "eslint-plugin-react-hooks": ">= 4.2.0"
   }


### PR DESCRIPTION
I've updated to all the latest versions and tried it on SC.

On SC we found around 70 new issues that were actually relevant, mostly raising some useless props that were not used anymore and easy to clean and some errors related to no-conditions-in-test that I cleaned.

There is also one new react rule ([react/jsx-no-leaked-render](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-leaked-render.md)) that seemed valuable but that I disabled because it generated a huge amount of false positives. You can find the PR with the SC changes here: https://github.com/SonarSource/sonarcloud-core/pull/3655

Regarding the warnings, we had the same amount as before.

Could you guys have a try on SQ and tell me if you think it makes sense to release like this or if we should disable or change some rules to warn? You can use version 2.0.0-rc to try it.