### PR TITLE
`jsx-sort-default-props` to `sort-default-props`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.1.2 (2023-03-13)
+
+Rules changes:
+
+- replace deprecated rule `jsx-sort-default-props` with `sort-default-props` from eslint-plugin-react v7.32.0
+
 # 2.1.1 (2023-01-05)
 
 Rules changes:

--- a/index.js
+++ b/index.js
@@ -170,7 +170,6 @@ module.exports = {
     "react/jsx-no-script-url": "error",
     "react/jsx-boolean-value": ["error", "always"],
     "react/jsx-pascal-case": "error",
-    "react/jsx-sort-default-props": "error",
     "react/jsx-fragments": "error",
     "react/jsx-curly-spacing": [
       "error",
@@ -203,6 +202,7 @@ module.exports = {
         groups: { rendering: ["/^render.+$/", "render"] },
       },
     ],
+    "react/sort-default-props": "error",
     "react/style-prop-object": "error",
     "react/void-dom-elements-no-children": "error",
     "react/hook-use-state": "error",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sonarqube",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "ESLint configuration for SonarQube and its plugins.",
   "main": "index.js",
   "license": "LGPL-3.0",
@@ -16,8 +16,8 @@
     "eslint-plugin-jest-dom": ">= 4.0.0",
     "eslint-plugin-jsx-a11y": ">= 6.5.0",
     "eslint-plugin-promise": ">= 6.0.0",
-    "eslint-plugin-testing-library":">= 5.0.0",
-    "eslint-plugin-react": ">= 7.30.0",
+    "eslint-plugin-testing-library": ">= 5.0.0",
+    "eslint-plugin-react": ">= 7.32.0",
     "eslint-plugin-react-hooks": ">= 4.3.0"
   }
 }


### PR DESCRIPTION
Update the deprecated rule name for the new rule name.
https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-sort-default-props.md

![Screenshot 2023-01-23 at 14 10 34](https://user-images.githubusercontent.com/97296331/214036760-d520b703-50f6-46bd-9676-5a0932429462.png)
