### PR TITLE
switch to using typescript-eslint/recommended which pulls in typescri…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.2.0 (2024-036-27)
+
+Rules changes:
+
+- switch from @typescript-eslint/eslint-recommended to @typescript-eslint/recommended
+
 # 2.1.3 (2023-06-16)
 
 Rules changes:

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: [
     "eslint:recommended",
-    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
     "plugin:import/errors",
     "plugin:jest/recommended",
     "plugin:jest-dom/recommended",
@@ -82,6 +82,8 @@ module.exports = {
     "no-useless-concat": "error",
     "no-useless-return": "error",
     "no-void": "error",
+    "prefer-rest-params": "warn",
+    "prefer-spread": "warn",
     radix: "error",
     "require-atomic-updates": "error",
     "require-await": "error",
@@ -122,13 +124,6 @@ module.exports = {
     "prefer-arrow-callback": "error",
     "prefer-destructuring": ["warn", { object: true, array: false }],
     "prefer-numeric-literals": "warn",
-
-    // override @typescript-eslint/eslint-recommended
-    "no-unused-vars": "off",
-    "no-array-constructor": "off",
-    "no-extra-semi": "off",
-    "prefer-rest-params": "warn",
-    "prefer-spread": "warn",
 
     // @typescript-eslint
     "no-useless-constructor": "off",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sonarqube",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "ESLint configuration for SonarQube and its plugins.",
   "main": "index.js",
   "license": "LGPL-3.0",


### PR DESCRIPTION
noticed no-unused-vars was no being logged.

I see it is being disabled, presumably because expecting the typescript-eslint version to be used, but that rule is never enabled.

Curious if should switch to using typescript-eslint/recommended which would enable no-unused-vars as well as some other rules